### PR TITLE
Provide git url and install apt/extensions at start

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,7 +34,7 @@ RUN pip install --upgrade pip && \
     @mflevine/jupyterlab_html \
     jupyterlab-drawio \
     @jupyterlab/plotly-extension \
-    jupyterlab_bokeh \
+    @bokeh/jupyter_bokeh \
     jupyterlab-spreadsheet \
     @jupyterlab/git
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ RUN curl -sL https://deb.nodesource.com/setup_12.x | bash - && \
 
 RUN pip install --upgrade pip && \
   pip install --upgrade \
-    jupyterlab==1.2.6 \
+    jupyterlab==2.0.1 \
     ipywidgets \
     jupyterlab_latex \
     plotly \

--- a/Dockerfile
+++ b/Dockerfile
@@ -33,7 +33,6 @@ RUN pip install --upgrade pip && \
   jupyter labextension install \
     @jupyter-widgets/jupyterlab-manager \
     @jupyterlab/latex \
-    @mflevine/jupyterlab_html \
     jupyterlab-drawio \
     @jupyterlab/plotly-extension \
     @bokeh/jupyter_bokeh \

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ RUN curl -sL https://deb.nodesource.com/setup_12.x | bash - && \
 
 RUN pip install --upgrade pip && \
   pip install --upgrade \
-    jupyterlab==2.0.1 \
+    jupyterlab==1.2.6 \
     ipywidgets \
     jupyterlab_latex \
     plotly \
@@ -33,10 +33,14 @@ RUN pip install --upgrade pip && \
   jupyter labextension install \
     @jupyter-widgets/jupyterlab-manager \
     @jupyterlab/latex \
-    # jupyterlab-drawio \ https://github.com/QuantStack/jupyterlab-drawio/issues/54
+    jupyterlab-drawio \ 
+    #https://github.com/QuantStack/jupyterlab-drawio/issues/54
     jupyterlab-plotly \
     @bokeh/jupyter_bokeh \
-    # @jupyterlab/git / # https://github.com/jupyterlab/jupyterlab-git/pull/520
+    @jupyterlab/git \
+    # https://github.com/jupyterlab/jupyterlab-git/pull/520
+    @mflevine/jupyterlab_html \
+    # ^to be removed at 2.0.1, now integrated
     jupyterlab-spreadsheet 
 
 COPY bin/entrypoint.sh /usr/local/bin/

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,8 +27,6 @@ RUN pip install --upgrade pip && \
     sympy \
     seaborn \
     nose \
-    rdflib \
-    SPARQLWrapper \
     jupyterlab-git && \
   jupyter labextension install \
     @jupyter-widgets/jupyterlab-manager \

--- a/Dockerfile
+++ b/Dockerfile
@@ -36,8 +36,8 @@ RUN pip install --upgrade pip && \
     # jupyterlab-drawio \ https://github.com/QuantStack/jupyterlab-drawio/issues/54
     jupyterlab-plotly \
     @bokeh/jupyter_bokeh \
-    jupyterlab-spreadsheet \
-    @jupyterlab/git
+    # @jupyterlab/git / # https://github.com/jupyterlab/jupyterlab-git/pull/520
+    jupyterlab-spreadsheet 
 
 COPY bin/entrypoint.sh /usr/local/bin/
 COPY config/ /root/.jupyter/

--- a/Dockerfile
+++ b/Dockerfile
@@ -33,8 +33,8 @@ RUN pip install --upgrade pip && \
   jupyter labextension install \
     @jupyter-widgets/jupyterlab-manager \
     @jupyterlab/latex \
-    jupyterlab-drawio \
-    @jupyterlab/plotly-extension \
+    # jupyterlab-drawio \ https://github.com/QuantStack/jupyterlab-drawio/issues/54
+    jupyterlab-plotly \
     @bokeh/jupyter_bokeh \
     jupyterlab-spreadsheet \
     @jupyterlab/git

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,13 +32,10 @@ RUN pip install --upgrade pip && \
     @jupyter-widgets/jupyterlab-manager \
     @jupyterlab/latex \
     jupyterlab-drawio \ 
-    #https://github.com/QuantStack/jupyterlab-drawio/issues/54
     jupyterlab-plotly \
     @bokeh/jupyter_bokeh \
     @jupyterlab/git \
-    # https://github.com/jupyterlab/jupyterlab-git/pull/520
     @mflevine/jupyterlab_html \
-    # ^to be removed at 2.0.1, now integrated
     jupyterlab-spreadsheet 
 
 COPY bin/entrypoint.sh /usr/local/bin/

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,6 +27,8 @@ RUN pip install --upgrade pip && \
     sympy \
     seaborn \
     nose \
+    rdflib \
+    SPARQLWrapper \
     jupyterlab-git && \
   jupyter labextension install \
     @jupyter-widgets/jupyterlab-manager \

--- a/README.md
+++ b/README.md
@@ -3,11 +3,11 @@
 [![Docker Pulls](https://img.shields.io/docker/pulls/amalic/jupyterlab.svg)](https://hub.docker.com/r/amalic/jupyterlab/)
 
 
-## Jupterlab Docker container
+## Jupyterlab Docker container
 
 **This Docker container runs as root user!** It can be helpful when e.g. the popular jupyter/datascience-notebook image does not work because it runs as Jovyan user. 
 
-#### Installed Jpyterlab extensions
+#### Installed Jupyterlab extensions
 - [Jupyter Widgets](https://ipywidgets.readthedocs.io/en/latest/examples/Widget%20Basics.html)
 - [@jupyterlab/latex](https://github.com/jupyterlab/jupyterlab-latex)
 - [jupyterlab-plotly](https://www.npmjs.com/package/jupyterlab-plotly)

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 - [@mflevine/jupyterlab_html](https://github.com/mflevine/jupyterlab_html)
 - [jupyterlab-drawio](https://github.com/QuantStack/jupyterlab-drawio)
 - [jupyterlab-spreadsheet](https://github.com/quigleyj97/jupyterlab-spreadsheet)
-- [jupyterlab_bokeh](https://github.com/bokeh/jupyterlab_bokeh)
+- [@bokeh/jupyter_bokeh](https://github.com/bokeh/jupyter_bokeh)
 - [@jupyterlab/toc](https://www.npmjs.com/package/@jupyterlab/toc)
 - [@jupyterlab/git](https://www.npmjs.com/package/@jupyterlab/git)
 
@@ -25,30 +25,34 @@ Volumes can be mounted into `/notebooks` folder. If the folder contains a requir
 ---
 
 ### Pull/Update to latest version
-```
+```bash
 docker pull amalic/jupyterlab:latest
 ```
 
 ### Run
-```
+```bash
 docker run --rm -it -p 8888:8888 amalic/jupyterlab
 ```
 
 or if you want to define your own password
-```
+```bash
 docker run --rm -it -p 8888:8888 -e PASSWORD="<your_secret>" amalic/jupyterlab
 ```
 
-or provide a Git repository to clone in `/notebooks` at start
+or provide a Git repository to clone in `/notebooks` when doing `docker run`
 
 ```bash
-docker run --rm -it -p 8888:8888 -v /data/notebooks-test:/notebooks -e PASSWORD="<your_secret>" -e GIT_URL="https://github.com/vemonet/translator-sparql-notebook" umids/jupyterlab:latest
+docker run --rm -it -p 8888:8888 -v /data/jupyterlab-notebooks:/notebooks -e PASSWORD="<your_secret>" -e GIT_URL="https://github.com/vemonet/translator-sparql-notebook" umids/jupyterlab:latest
 ```
 
+> Access on http://localhost:8888 and files shared in `/data/jupyterlab-notebooks`
 
+If the Git repository contains a `requirements.txt` or `jupyter_install.sh` at its root, they will be executed at runtime.
+
+> The `jupyter_install.sh` script allows to install Jupyter extensions, such as new kernels, at runtime using Bash. e.g. `jupyter sparqlkernel install --user`
 
 ### Build from source
 
-```
+```bash
 docker build -t amalic/jupyterlab .
 ```

--- a/README.md
+++ b/README.md
@@ -47,9 +47,19 @@ docker run --rm -it -p 8888:8888 -v /data/jupyterlab-notebooks:/notebooks -e PAS
 
 > Access on http://localhost:8888 and files shared in `/data/jupyterlab-notebooks`
 
-If the Git repository contains a `requirements.txt` or `packages.txt` (for apt packages) or `extensions.txt` (for ) at its root, they will be executed at runtime.
+or use the current directory in the container:
 
-> The `jupyter_install.sh` script allows to install Jupyter extensions, such as new kernels, at runtime using Bash. e.g. `jupyter sparqlkernel install --user`
+```bash
+docker run --rm -it -p 8888:8888 -v $(pwd):/notebooks -e PASSWORD="<your_secret>" umids/jupyterlab:latest
+```
+
+> Use `${pwd}` for Windows
+
+The container will install requirements from files present at the root of the repository at `docker run` (in this order):
+
+* `packages.txt`: install apt-get packages
+* `requirements.txt`: install pip packages
+* `extensions.txt`: install Jupyterlab extensions
 
 ### Build from source
 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,16 @@ or if you want to define your own password
 docker run --rm -it -p 8888:8888 -e PASSWORD="<your_secret>" amalic/jupyterlab
 ```
 
+or provide a Git repository to clone in `/notebooks` at start
+
+```bash
+docker run --rm -it -p 8888:8888 -v /data/notebooks-test:/notebooks -e PASSWORD="<your_secret>" -e GIT_URL="https://github.com/vemonet/translator-sparql-notebook" umids/jupyterlab:latest
+```
+
+
+
 ### Build from source
+
 ```
 docker build -t amalic/jupyterlab .
 ```

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ docker run --rm -it -p 8888:8888 -v /data/jupyterlab-notebooks:/notebooks -e PAS
 
 > Access on http://localhost:8888 and files shared in `/data/jupyterlab-notebooks`
 
-If the Git repository contains a `requirements.txt` or `jupyter_install.sh` at its root, they will be executed at runtime.
+If the Git repository contains a `requirements.txt` or `packages.txt` (for apt packages) or `extensions.txt` (for ) at its root, they will be executed at runtime.
 
 > The `jupyter_install.sh` script allows to install Jupyter extensions, such as new kernels, at runtime using Bash. e.g. `jupyter sparqlkernel install --user`
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 #### Installed Jpyterlab extensions
 - [Jupyter Widgets](https://ipywidgets.readthedocs.io/en/latest/examples/Widget%20Basics.html)
 - [@jupyterlab/latex](https://github.com/jupyterlab/jupyterlab-latex)
-- [@jupyterlab/plotly-extension](https://github.com/jupyterlab/jupyter-renderers/tree/master/packages/plotly-extension)
+- [jupyterlab-plotly](https://www.npmjs.com/package/jupyterlab-plotly)
 - [@mflevine/jupyterlab_html](https://github.com/mflevine/jupyterlab_html)
 - [jupyterlab-drawio](https://github.com/QuantStack/jupyterlab-drawio)
 - [jupyterlab-spreadsheet](https://github.com/quigleyj97/jupyterlab-spreadsheet)
@@ -39,7 +39,15 @@ or if you want to define your own password
 docker run --rm -it -p 8888:8888 -e PASSWORD="<your_secret>" amalic/jupyterlab
 ```
 
-or provide a Git repository to clone in `/notebooks` when doing `docker run`
+The container will install requirements from files present at the root of the repository at `docker run` (in this order):
+
+* `packages.txt`: install apt-get packages
+* `requirements.txt`: install pip packages
+* `extensions.txt`: install Jupyterlab extensions
+
+### Run from Git repository
+
+You can provide a Git repository to be cloned in `/notebooks` when doing `docker run`
 
 ```bash
 docker run --rm -it -p 8888:8888 -v /data/jupyterlab-notebooks:/notebooks -e PASSWORD="<your_secret>" -e GIT_URL="https://github.com/vemonet/translator-sparql-notebook" umids/jupyterlab:latest
@@ -47,19 +55,13 @@ docker run --rm -it -p 8888:8888 -v /data/jupyterlab-notebooks:/notebooks -e PAS
 
 > Access on http://localhost:8888 and files shared in `/data/jupyterlab-notebooks`
 
-or use the current directory in the container:
+or use the current directory as source code in the container:
 
 ```bash
 docker run --rm -it -p 8888:8888 -v $(pwd):/notebooks -e PASSWORD="<your_secret>" umids/jupyterlab:latest
 ```
 
 > Use `${pwd}` for Windows
-
-The container will install requirements from files present at the root of the repository at `docker run` (in this order):
-
-* `packages.txt`: install apt-get packages
-* `requirements.txt`: install pip packages
-* `extensions.txt`: install Jupyterlab extensions
 
 ### Build from source
 

--- a/bin/entrypoint.sh
+++ b/bin/entrypoint.sh
@@ -13,7 +13,8 @@ fi
 
 if [ -f /notebooks/packages.txt ]; then
   echo "INFO: Found packages.txt file in folder /notebooks. Executing it to install apt packages."
-  cat extensions.txt | xargs apt-get install
+  apt-get update
+  cat packages.txt | xargs apt-get install -y
 else
   echo "INFO: packages.txt not found in folder /notebooks --> Continuing"
 fi

--- a/bin/entrypoint.sh
+++ b/bin/entrypoint.sh
@@ -11,11 +11,11 @@ if [[ -v GIT_URL ]]; then
   git clone $GIT_URL /notebooks
 fi
 
-if [ -f /notebooks/install.sh ]; then
-  echo "INFO: Found install.sh file in folder /notebooks. Executing it to install apt packages, Jupyter extensions and kernels."
-  ./install.sh
+if [ -f /notebooks/packages.txt ]; then
+  echo "INFO: Found packages.txt file in folder /notebooks. Executing it to install apt packages."
+  xargs -a packages.txt sudo apt-get install
 else
-  echo "INFO: install.sh not found in folder /notebooks --> Continuing"
+  echo "INFO: packages.txt not found in folder /notebooks --> Continuing"
 fi
 
 if [ -f /notebooks/requirements.txt ]; then
@@ -23,6 +23,13 @@ if [ -f /notebooks/requirements.txt ]; then
   pip install -r requirements.txt
 else
   echo "INFO: requirements.txt not found in folder /notebooks --> Continuing"
+fi
+
+if [ -f /notebooks/extensions.txt ]; then
+  echo "INFO: Found extensions.txt file in folder /notebooks. Installing via \"jupyter extension install --user\""
+  cat extensions.txt | xargs -I {} echo jupyter {} install --user
+else
+  echo "INFO: extensions.txt not found in folder /notebooks --> Continuing"
 fi
 
 echo

--- a/bin/entrypoint.sh
+++ b/bin/entrypoint.sh
@@ -19,7 +19,7 @@ else
 fi
 
 if [ -f /notebooks/jupyter_install.sh ]; then
-  echo "INFO: Found jupyter_install.sh file in folder /notebooks. Executing it."
+  echo "INFO: Found jupyter_install.sh file in folder /notebooks. Executing it to install additional Jupyter extensions and kernels."
   ./jupyter_install.sh
 else
   echo "INFO: jupyter_install.sh not found in folder /notebooks --> Continuing"

--- a/bin/entrypoint.sh
+++ b/bin/entrypoint.sh
@@ -11,7 +11,7 @@ if [[ -v GIT_URL ]]; then
   git clone $GIT_URL /notebooks
 fi
 
-if [ -f /notebooks/jupyter_install.sh ]; then
+if [ -f /notebooks/install.sh ]; then
   echo "INFO: Found install.sh file in folder /notebooks. Executing it to install apt packages, Jupyter extensions and kernels."
   ./install.sh
 else

--- a/bin/entrypoint.sh
+++ b/bin/entrypoint.sh
@@ -18,6 +18,13 @@ else
   echo "INFO: requirements.txt not found in folder /notebooks --> Continuing"
 fi
 
+if [ -f /notebooks/jupyter_install.sh ]; then
+  echo "INFO: Found jupyter_install.sh file in folder /notebooks. Executing it."
+  ./jupyter_install.sh
+else
+  echo "INFO: jupyter_install.sh not found in folder /notebooks --> Continuing"
+fi
+
 echo
 echo "Installed software:"
 python --version

--- a/bin/entrypoint.sh
+++ b/bin/entrypoint.sh
@@ -13,7 +13,7 @@ fi
 
 if [ -f /notebooks/packages.txt ]; then
   echo "INFO: Found packages.txt file in folder /notebooks. Executing it to install apt packages."
-  xargs -a packages.txt sudo apt-get install
+  cat extensions.txt | xargs apt-get install
 else
   echo "INFO: packages.txt not found in folder /notebooks --> Continuing"
 fi
@@ -27,7 +27,7 @@ fi
 
 if [ -f /notebooks/extensions.txt ]; then
   echo "INFO: Found extensions.txt file in folder /notebooks. Installing via \"jupyter extension install --user\""
-  cat extensions.txt | xargs -I {} echo jupyter {} install --user
+  cat extensions.txt | xargs -I {} jupyter {} install --user
 else
   echo "INFO: extensions.txt not found in folder /notebooks --> Continuing"
 fi

--- a/bin/entrypoint.sh
+++ b/bin/entrypoint.sh
@@ -11,18 +11,18 @@ if [[ -v GIT_URL ]]; then
   git clone $GIT_URL /notebooks
 fi
 
+if [ -f /notebooks/jupyter_install.sh ]; then
+  echo "INFO: Found install.sh file in folder /notebooks. Executing it to install apt packages, Jupyter extensions and kernels."
+  ./install.sh
+else
+  echo "INFO: install.sh not found in folder /notebooks --> Continuing"
+fi
+
 if [ -f /notebooks/requirements.txt ]; then
   echo "INFO: Found requirements.txt file in folder /notebooks. Installing via \"pip install -r requirements.txt\""
   pip install -r requirements.txt
 else
   echo "INFO: requirements.txt not found in folder /notebooks --> Continuing"
-fi
-
-if [ -f /notebooks/jupyter_install.sh ]; then
-  echo "INFO: Found jupyter_install.sh file in folder /notebooks. Executing it to install additional Jupyter extensions and kernels."
-  ./jupyter_install.sh
-else
-  echo "INFO: jupyter_install.sh not found in folder /notebooks --> Continuing"
 fi
 
 echo

--- a/bin/entrypoint.sh
+++ b/bin/entrypoint.sh
@@ -7,6 +7,10 @@ if [[ -v PASSWORD ]]; then
   CMD="$CMD --NotebookApp.token='' --NotebookApp.password='${PASSWORD}'"
 fi
 
+if [[ -v GIT_URL ]]; then
+  git clone $GIT_URL /notebooks
+fi
+
 if [ -f /notebooks/requirements.txt ]; then
   echo "INFO: Found requirements.txt file in folder /notebooks. Installing via \"pip install -r requirements.txt\""
   pip install -r requirements.txt


### PR DESCRIPTION
Allow to provide a Git URL through Docker env variable at `docker run` to clone the repository

Add extensions.txt and packages.txt to be parsed to install jupyterlab extensions and apt packages in entrypoint (similar to requirements.txt)

The new features are documented in the readme

Example of repo providing the 3 requirements files: https://github.com/vemonet/translator-sparql-notebook