### PR TITLE
Upgrade to JupyterLab 2.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,8 @@ RUN pip install --upgrade pip && \
   pip install --upgrade \
     jupyterlab>=2.0.0 \
     ipywidgets \
+    jedi==0.15.2 \ 
+    # jupyterlab-lsp does not support 0.17
     jupyterlab_latex \
     plotly \
     bokeh \
@@ -27,6 +29,8 @@ RUN pip install --upgrade pip && \
     sympy \
     seaborn \
     nose \
+    jupyter-lsp \
+    python-language-server \
     jupyterlab-git && \
   jupyter labextension install \
     @jupyter-widgets/jupyterlab-manager \
@@ -34,6 +38,7 @@ RUN pip install --upgrade pip && \
     jupyterlab-drawio \ 
     jupyterlab-plotly \
     @bokeh/jupyter_bokeh \
+    @krassowski/jupyterlab-lsp \
     @jupyterlab/git \
     jupyterlab-spreadsheet 
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ RUN curl -sL https://deb.nodesource.com/setup_12.x | bash - && \
 
 RUN pip install --upgrade pip && \
   pip install --upgrade \
-    jupyterlab==1.2.6 \
+    jupyterlab>=2.0.0 \
     ipywidgets \
     jupyterlab_latex \
     plotly \
@@ -35,7 +35,6 @@ RUN pip install --upgrade pip && \
     jupyterlab-plotly \
     @bokeh/jupyter_bokeh \
     @jupyterlab/git \
-    @mflevine/jupyterlab_html \
     jupyterlab-spreadsheet 
 
 COPY bin/entrypoint.sh /usr/local/bin/

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ The container will install requirements from files present at the root of the re
 You can provide a Git repository to be cloned in `/notebooks` when doing `docker run`
 
 ```bash
-docker run --rm -it -p 8888:8888 -v /data/jupyterlab-notebooks:/notebooks -e PASSWORD="<your_secret>" -e GIT_URL="https://github.com/vemonet/translator-sparql-notebook" umids/jupyterlab:latest
+docker run --rm -it -p 8888:8888 -v /data/jupyterlab-notebooks:/notebooks -e PASSWORD="<your_secret>" -e GIT_URL="https://github.com/vemonet/translator-sparql-notebook" amalic/jupyterlab:latest
 ```
 
 > Access on http://localhost:8888 and files shared in `/data/jupyterlab-notebooks`
@@ -58,7 +58,7 @@ docker run --rm -it -p 8888:8888 -v /data/jupyterlab-notebooks:/notebooks -e PAS
 or use the current directory as source code in the container:
 
 ```bash
-docker run --rm -it -p 8888:8888 -v $(pwd):/notebooks -e PASSWORD="<your_secret>" umids/jupyterlab:latest
+docker run --rm -it -p 8888:8888 -v $(pwd):/notebooks -e PASSWORD="<your_secret>" amalic/jupyterlab:latest
 ```
 
 > Use `${pwd}` for Windows


### PR DESCRIPTION
Drawio and Git Jupyterlab extensions now supports 2.0

I added jupyterlab-lsp for autocomplete and linting! It is beautiful, JupyterLab is now a full blown IDE!

I needed to downgrade `jedi` package from 0.17.0 to 0.15.2 for LSP

Also fixed some docker images that were still pointing to umids dockerhub in readme